### PR TITLE
feat : DB full-text search vs like

### DIFF
--- a/src/main/java/com/example/baedal/controller/SearchController.java
+++ b/src/main/java/com/example/baedal/controller/SearchController.java
@@ -4,6 +4,8 @@ import com.example.baedal.dto.request.SearchRequestDto;
 import com.example.baedal.dto.response.ResponseDto;
 import com.example.baedal.service.SearchService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -14,8 +16,31 @@ public class SearchController {
 
     private final SearchService searchService;
 
-    @PostMapping(value = "/api/search")
-    public ResponseDto<?> postOrder(@RequestBody SearchRequestDto requestDto) {
-        return searchService.search(requestDto);
+    /*problem:
+    member 주소와 상점의 주소가 정확시 일치해야
+    해당하는 store을 반환함*/
+//    @PostMapping(value = "/api/search")
+//    public ResponseDto<?> postOrder(@RequestBody SearchRequestDto requestDto) {
+//        return searchService.search(requestDto);
+//    }
+
+    /*
+    * '시'단위까지 일치하는 가게들은 모두 반환
+    * v1) DB like 기능 사용*/
+    @PostMapping(value = "/api/v1/search")
+    public ResponseDto<?> postOrderV1(@RequestBody SearchRequestDto requestDto,
+                                      @PageableDefault(page = 0, size = 10) Pageable pageable) {
+        return searchService.searchV1(requestDto,pageable);
     }
+
+    /*
+     * '시'단위까지 일치하는 가게들은 모두 반환
+     * v2) DB full-text search 기능 사용*/
+    @PostMapping(value = "/api/v2/search")
+    public ResponseDto<?> postOrderV2(@RequestBody SearchRequestDto requestDto,
+                                      @PageableDefault(page = 0, size = 10) Pageable pageable) {
+        return searchService.searchV2(requestDto,pageable);
+    }
+
+
 }

--- a/src/main/java/com/example/baedal/dto/request/SearchRequestDto.java
+++ b/src/main/java/com/example/baedal/dto/request/SearchRequestDto.java
@@ -10,6 +10,11 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 public class SearchRequestDto {
-    private String keyword;
+//    private String keyword;
+//    private Long memberId;
+
+    /*v1) DB like로 search*/
     private Long memberId;
 }
+
+

--- a/src/main/java/com/example/baedal/repository/StoreRepository/StoreRepository.java
+++ b/src/main/java/com/example/baedal/repository/StoreRepository/StoreRepository.java
@@ -1,6 +1,7 @@
 package com.example.baedal.repository.StoreRepository;
 
 import com.example.baedal.domain.Store;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -16,8 +17,17 @@ public interface StoreRepository extends JpaRepository<Store, Long>, StoreReposi
     @Query(value = "UPDATE Store s SET s.avgStar = :finalStar WHERE s.storeId = :id")
     void updateAvgStar(@Param("finalStar") double finalStar, @Param("id") Long id);
 
-    List<Store> findByNameContainsAndAddressContains(String name, String address);
+    //List<Store> findByNameContainsAndAddressContains(String name, String address);
 
     Optional<Store> findByStoreId(Long storeId);
 
+    /*v1) table full scan 사용*/
+    @Query(value = "SELECT s FROM Store s WHERE s.address LIKE %:address%")
+    List<Store> findByAddressV1(@Param("address") String address, Pageable pageable);
+
+    /*v2) DB indexing/full-text search 사용*/
+    /*alter table store add fulltext (address); MySQL에서 설정 필요*/
+    @Query(value = "SELECT * FROM Store s WHERE MATCH(s.address) AGAINST((?1) IN NATURAL LANGUAGE MODE)",
+            nativeQuery = true)
+    List<Store> findByAddressV2(@Param("address") String address, Pageable pageable);
 }

--- a/src/main/java/com/example/baedal/service/SearchService.java
+++ b/src/main/java/com/example/baedal/service/SearchService.java
@@ -4,9 +4,11 @@ import com.example.baedal.domain.Member;
 import com.example.baedal.domain.Store;
 import com.example.baedal.dto.request.SearchRequestDto;
 import com.example.baedal.dto.response.ResponseDto;
+import com.example.baedal.error.ErrorCode;
 import com.example.baedal.repository.MemberRepository.MemberRepository;
 import com.example.baedal.repository.StoreRepository.StoreRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,13 +21,58 @@ public class SearchService {
     private final StoreRepository storeRepository;
     private final MemberRepository memberRepository;
 
+    /*problem:
+    member 주소와 상점의 주소가 정확시 일치해야
+    해당하는 store을 반환*/
+//    @Transactional
+//    public ResponseDto<?> search(SearchRequestDto requestDto) {
+//        Member member = memberRepository.findByMemberId(requestDto.getMemberId()).orElse(null);
+//        if(null == member) {
+//            return ResponseDto.fail("NOT_FOUND", "memberId is not exist");
+//        }
+//        List<Store> stores = storeRepository.findByNameContainsAndAddressContains(requestDto.getKeyword(), member.getAddress());
+//        return ResponseDto.success(stores);
+//    }
+
+    /*
+     * '시'단위까지 일치하는 가게들은 모두 반환
+     * cons) table full scan 실행
+     * v1) DB like 기능 사용*/
     @Transactional
-    public ResponseDto<?> search(SearchRequestDto requestDto) {
-        Member member = memberRepository.findByMemberId(requestDto.getMemberId()).orElse(null);
-        if(null == member) {
-            return ResponseDto.fail("NOT_FOUND", "memberId is not exist");
-        }
-        List<Store> stores = storeRepository.findByNameContainsAndAddressContains(requestDto.getKeyword(), member.getAddress());
+    public ResponseDto<?> searchV1(SearchRequestDto requestDto, Pageable pageable) {
+        //memberId로 member 찾기
+        Member member = memberRepository.findByMemberId(requestDto.getMemberId())
+                .orElseThrow(() -> new IllegalArgumentException(ErrorCode.MEMBER_NOT_FOUND.getMessage()));
+
+        //member의 address에서 '시'단위까지만 추출(주소가 시로 시작한다고 가정)
+        String[] address = member.getAddress().split(" ");
+        //System.out.println("주소 시까지 잘 나오나 보자" + address[0]);
+        List<Store> stores = storeRepository.findByAddressV1(address[0],pageable);
+
         return ResponseDto.success(stores);
     }
+
+
+    /*
+     *'시'단위까지 일치하는 가게들은 모두 반환
+     * 1.DB indexing 사용하여 생성하고 싶은 인덱스 컬럼을 지정하고
+     * 2.생성 후 인덱스 조회 시, where 절이 포함된 쿼리를 조회
+     * 3.인덱스로 저장된 key-value 값을 참조해서 결과 출력
+     * pros) table full scan을 하지 않아도 되므로 성능이 좋음
+     * v2) DB full text search 사용 */
+    @Transactional
+    public ResponseDto<?> searchV2(SearchRequestDto requestDto, Pageable pageable) {
+        //memberId로 member 찾기
+        Member member = memberRepository.findByMemberId(requestDto.getMemberId())
+                .orElseThrow(() -> new IllegalArgumentException(ErrorCode.MEMBER_NOT_FOUND.getMessage()));
+
+        //member의 address에서 '시'단위까지만 추출
+        String[] address = member.getAddress().split(" ");
+
+        //DB indexing 후 full text search 이용해서 해당 Store 반환
+        List<Store> stores = storeRepository.findByAddressV2(address[0],pageable);
+
+        return ResponseDto.success(stores);
+    }
+
 }


### PR DESCRIPTION
member 주소와 일치하는 stores response

-

## 어떤 것에 대한 PR인가요? :mag:
full-text search(v1) vs like(v2) 사용해서 member address에 해당하는 stores response 해주는 api 추가
아직 Exception 처리를 미완, index Entity(full text index 생성해야 하기 떄문에) 만드는 과정은 더 서치하고 추가할 예정이므로 mySQL에 'alter table store drop index address' 추가 후 사용해야 합니다.

## 변경사항 :memo:

## 코멘트 :page_with_curl:
